### PR TITLE
Simhash Token/Char Frequency Floor/Ceiling, and more.

### DIFF
--- a/py/htm/examples/encoders/simhash_document_encoder.py
+++ b/py/htm/examples/encoders/simhash_document_encoder.py
@@ -18,136 +18,171 @@
 
 import htm.bindings.encoders
 SimHashDocumentEncoder = htm.bindings.encoders.SimHashDocumentEncoder
-SimHashDocumentEncoderParameters = htm.bindings.encoders.SimHashDocumentEncoderParameters
+SimHashDocumentEncoderParameters = \
+    htm.bindings.encoders.SimHashDocumentEncoderParameters
 
 
 if __name__ == '__main__':
-  """
-  Simple program to examine the SimHashDocumentEncoder.
+    """
+    Simple program to examine the SimHashDocumentEncoder.
 
-  For help using this program run:
-  $ python -m htm.examples.encoders.simhash_document_encoder --help
-  """
-  import argparse
-  import numpy
-  import random
-  import sys
-  import textwrap
+    For help using this program run:
+    $ python -m htm.examples.encoders.simhash_document_encoder --help
+    """
+    import argparse
+    import numpy
+    import random
+    import sys
+    import textwrap
 
-  from htm.bindings.sdr import SDR, Metrics
+    from htm.bindings.sdr import Metrics
 
-  # Gather input from the user.
-  parser = argparse.ArgumentParser(
-      formatter_class=argparse.RawDescriptionHelpFormatter,
-      description="Simple program to examine the SimHashDocumentEncoder.\n\n" +
-      textwrap.dedent(SimHashDocumentEncoder.__doc__ + "\n\n" +
-                      SimHashDocumentEncoderParameters.__doc__))
-  parser.add_argument('--activeBits', type=int, default=0,
-                      help=SimHashDocumentEncoderParameters.activeBits.__doc__)
-  parser.add_argument('--caseSensitivity', action='store_true', default=False,
-                      help=SimHashDocumentEncoderParameters.caseSensitivity.__doc__)
-  parser.add_argument('--size', type=int, default=0,
-                      help=SimHashDocumentEncoderParameters.size.__doc__)
-  parser.add_argument('--sparsity', type=float, default=0,
-                      help=SimHashDocumentEncoderParameters.sparsity.__doc__)
-  parser.add_argument('--tokenSimilarity', action='store_true', default=False,
-                      help=SimHashDocumentEncoderParameters.tokenSimilarity.__doc__)
-  args = parser.parse_args()
+    # Gather input from the user.
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Simple program to examine the SimHashDocumentEncoder."
+                    + textwrap.dedent(
+                        SimHashDocumentEncoder.__doc__ + "\n\n"
+                        + SimHashDocumentEncoderParameters.__doc__))
+    parser.add_argument(
+        '--activeBits', type=int,  default=0,
+        help=SimHashDocumentEncoderParameters.activeBits.__doc__)
+    parser.add_argument(
+        '--caseSensitivity', action='store_true', default=False,
+        help=SimHashDocumentEncoderParameters.caseSensitivity.__doc__)
+    parser.add_argument(
+        '--charFrequencyCeiling', type=int, default=0,
+        help=SimHashDocumentEncoderParameters.charFrequencyCeiling.__doc__)
+    parser.add_argument(
+        '--charFrequencyFloor', type=int, default=0,
+        help=SimHashDocumentEncoderParameters.charFrequencyFloor.__doc__)
+    parser.add_argument(
+        '--encodeOrphans', action='store_true', default=False,
+        help=SimHashDocumentEncoderParameters.encodeOrphans.__doc__)
+    parser.add_argument(
+        '--excludes', type=list, default=[],
+        help=SimHashDocumentEncoderParameters.excludes.__doc__)
+    parser.add_argument(
+        '--size', type=int, default=0,
+        help=SimHashDocumentEncoderParameters.size.__doc__)
+    parser.add_argument(
+        '--sparsity', type=float, default=0,
+        help=SimHashDocumentEncoderParameters.sparsity.__doc__)
+    parser.add_argument(
+        '--tokenFrequencyCeiling', type=int, default=0,
+        help=SimHashDocumentEncoderParameters.tokenFrequencyCeiling.__doc__)
+    parser.add_argument(
+        '--tokenFrequencyFloor', type=int, default=0,
+        help=SimHashDocumentEncoderParameters.tokenFrequencyFloor.__doc__)
+    parser.add_argument(
+        '--tokenSimilarity', action='store_true', default=False,
+        help=SimHashDocumentEncoderParameters.tokenSimilarity.__doc__)
+    parser.add_argument(
+        '--vocabulary', type=dict, default={},
+        help=SimHashDocumentEncoderParameters.vocabulary.__doc__)
+    args = parser.parse_args()
 
-  # Copy the command line arguments into the parameter structure.
-  parameters = SimHashDocumentEncoderParameters()
-  parameters.activeBits = args.activeBits
-  parameters.caseSensitivity = args.caseSensitivity
-  parameters.size = args.size
-  parameters.sparsity = args.sparsity
-  parameters.tokenSimilarity = args.tokenSimilarity
+    # Copy the command line arguments into the parameter structure.
+    parameters = SimHashDocumentEncoderParameters()
+    parameters.activeBits = args.activeBits
+    parameters.caseSensitivity = args.caseSensitivity
+    parameters.charFrequencyCeiling = args.charFrequencyCeiling
+    parameters.charFrequencyFloor = args.charFrequencyFloor
+    parameters.encodeOrphans = args.encodeOrphans
+    parameters.excludes = args.excludes
+    parameters.size = args.size
+    parameters.sparsity = args.sparsity
+    parameters.tokenFrequencyCeiling = args.tokenFrequencyCeiling
+    parameters.tokenFrequencyFloor = args.tokenFrequencyFloor
+    parameters.tokenSimilarity = args.tokenSimilarity
+    parameters.vocabulary = args.vocabulary
 
-  # Try initializing the encoder.
-  try:
-    encoder = SimHashDocumentEncoder(parameters)
-  except RuntimeError as error:
-    print(error)
-    parser.print_usage()
-    sys.exit()
+    # Try initializing the encoder.
+    try:
+        encoder = SimHashDocumentEncoder(parameters)
+    except RuntimeError as error:
+        print(error)
+        parser.print_usage()
+        sys.exit()
 
-  # Run the encoder and measure some statistics about its output.
-  num_samples = 1000  # number of documents to run
-  num_tokens = 10  # tokens per document
-  testCorpus = ["find", "any", "new", "work", "part", "take", "get", "place",
-                "made", "live", "where", "after", "back", "little", "only", "round", "man",
-                "year", "came", "show", "every", "good", "me", "give", "our", "under",
-                "name", "very", "through", "just", "form", "sentence", "great", "think",
-                "say", "help", "low", "line", "differ", "turn", "cause", "much", "mean",
-                "before", "move", "right", "boy", "old", "too", "same", "tell", "does",
-                "set", "three", "want", "air", "well", "also", "play", "small", "end",
-                "put", "home", "read", "hand", "port", "large", "spell", "add", "even",
-                "land", "here", "must", "big", "high", "such", "follow", "act", "why",
-                "ask", "men", "change", "went", "light", "kind", "off", "need", "house",
-                "picture", "try", "us", "again", "animal", "point", "mother", "world",
-                "near", "build", "self", "earth"]  # 100 simple common english words
-  documents = []
-  sdrs = []
-  reference = {}  # reference document to compare against for similarity checks
-  similar = {}  # most similar document to the reference
-  unsimilar = {}  # least similar document against reference
-  def distance(a, b): return numpy.count_nonzero(a != b)
+    # Run the encoder and measure some statistics about its output.
+    num_samples = 1000  # number of documents to run
+    num_tokens = 10     # tokens per document
+    testCorpus = [      # 100 simple common english words
+        "find", "any", "new", "work", "part", "take", "get", "place", "made",
+        "live", "where", "after", "back", "little", "only", "round", "man",
+        "year", "came", "show", "every", "good", "me", "give", "our", "under",
+        "name", "very", "through", "just", "form", "sentence", "great",
+        "think", "say", "help", "low", "line", "differ", "turn", "cause",
+        "much", "mean", "before", "move", "right", "boy", "old", "too", "same",
+        "tell", "does", "set", "three", "want", "air", "well", "also", "play",
+        "small", "end", "put", "home", "read", "hand", "port", "large",
+        "spell", "add", "even", "land", "here", "must", "big", "high", "such",
+        "follow", "act", "why", "ask", "men", "change", "went", "light",
+        "kind", "off", "need", "house", "picture", "try", "us", "again",
+        "animal", "point", "mother", "world", "near", "build", "self", "earth"]
+    documents = []
+    sdrs = []
+    reference = {}  # reference document to compare against for similarity
+    similar = {}  # most similar document to the reference
+    unsimilar = {}  # least similar document against reference
+    def distance(a, b): return numpy.count_nonzero(a != b)
 
-  for _ in range(num_samples):
-    document = []
-    for _ in range(num_tokens - 1):
-      document.append(testCorpus[random.randint(0, len(testCorpus) - 1)])
-    document.sort()
-    documents.append(document)
-    sdr = encoder.encode(document)
-    sdrs.append(sdr)
+    for _ in range(num_samples):
+        document = []
+        for _ in range(num_tokens - 1):
+            document.append(testCorpus[random.randint(0, len(testCorpus) - 1)])
+        document.sort()
+        documents.append(document)
+        sdr = encoder.encode(document)
+        sdrs.append(sdr)
 
-    # similarity checking
-    current = numpy.zeros([encoder.size], dtype=numpy.uint8)
-    current[:] = sdr.dense
+        # similarity checking
+        current = numpy.zeros([encoder.size], dtype=numpy.uint8)
+        current[:] = sdr.dense
 
-    if not reference:
-      reference = {"doc": document, "bits": current}
-    else:
-      if not similar:
-        similar = {"doc": document, "bits": current}
-      else:
-        if (distance(current, reference["bits"]) <
-                distance(similar["bits"], reference["bits"])):
-          similar = {"doc": document, "bits": current}
+        if not reference:
+            reference = {"doc": document, "bits": current}
+        else:
+            if not similar:
+                similar = {"doc": document, "bits": current}
+            else:
+                if (distance(current, reference["bits"])
+                        < distance(similar["bits"], reference["bits"])):
+                    similar = {"doc": document, "bits": current}
 
-      if not unsimilar:
-        unsimilar = {"doc": document, "bits": current}
-      else:
-        if (distance(current, reference["bits"]) >
-                distance(unsimilar["bits"], reference["bits"])):
-          unsimilar = {"doc": document, "bits": current}
+            if not unsimilar:
+                unsimilar = {"doc": document, "bits": current}
+            else:
+                if (distance(current, reference["bits"])
+                        > distance(unsimilar["bits"], reference["bits"])):
+                    unsimilar = {"doc": document, "bits": current}
 
-  report = Metrics([encoder.size], len(sdrs) + 1)
-  for sdr in sdrs:
-    report.addData(sdr)
+    report = Metrics([encoder.size], len(sdrs) + 1)
+    for sdr in sdrs:
+        report.addData(sdr)
 
-  print("Statistics:")
-  print("\tEncoded %d Document inputs." % len(sdrs))
-  print("\tOutput: " + str(report))
+    print("Statistics:")
+    print("\tEncoded %d Document inputs." % len(sdrs))
+    print("\tOutput: " + str(report))
 
-  print("Similarity:")
-  print("\tReference:\n\t\t" + str(reference["doc"]))
-  print("\tMOST Similar (Distance = " +
-        str(distance(similar["bits"], reference["bits"])) + "):")
-  print("\t\t" + str(similar["doc"]))
-  print("\tLEAST Similar (Distance = " +
-        str(distance(unsimilar["bits"], reference["bits"])) + "):")
-  print("\t\t" + str(unsimilar["doc"]))
+    print("Similarity:")
+    print("\tReference:\n\t\t" + str(reference["doc"]))
+    print("\tMOST Similar (Distance = " + str(
+        distance(similar["bits"], reference["bits"])) + "):")
+    print("\t\t" + str(similar["doc"]))
+    print("\tLEAST Similar (Distance = " + str(
+        distance(unsimilar["bits"], reference["bits"])) + "):")
+    print("\t\t" + str(unsimilar["doc"]))
 
-  # Plot the Receptive Field of each bit in the encoder.
-  import matplotlib.pyplot as plot
-  if 'matplotlib.pyplot' in sys.modules:
-    field = numpy.zeros([encoder.size, len(sdrs)], dtype=numpy.uint8)
-    for i in range(len(sdrs)):
-      field[:, i] = sdrs[i].dense
-    plot.imshow(field, interpolation='nearest')
-    plot.title("SimHash Document Encoder - Receptive Fields")
-    plot.xlabel("Input Document #")
-    plot.ylabel("SDR Bit #")
-    plot.show()
-
+    # Plot the Receptive Field of each bit in the encoder.
+    import matplotlib.pyplot as plot
+    if 'matplotlib.pyplot' in sys.modules:
+        field = numpy.zeros([encoder.size, len(sdrs)], dtype=numpy.uint8)
+        for i in range(len(sdrs)):
+            field[:, i] = sdrs[i].dense
+        plot.imshow(field, interpolation='nearest')
+        plot.title("SimHash Document Encoder - Receptive Fields")
+        plot.xlabel("Input Document #")
+        plot.ylabel("SDR Bit #")
+        plot.show()

--- a/src/htm/encoders/SimHashDocumentEncoder.hpp
+++ b/src/htm/encoders/SimHashDocumentEncoder.hpp
@@ -42,6 +42,23 @@ namespace htm {
     UInt activeBits = 0u;
 
     /**
+     * @param :charFrequencyCeiling: If param `tokenSimilarity` is on, this will
+     *  be the max number of times a char/letter can be repeated in a token.
+     *  Occurances of the character beyond this number will be discarded.
+     *  A setting of 1 will act as character de-duplication, guaranteeing each
+     *  character in a token is unique. Inverse to param `charFrequencyFloor`.
+     */
+    UInt charFrequencyCeiling = 0u;
+
+    /**
+     * @param :charFrequencyFloor: If param `tokenSimilarity` is on, and if this
+     *  option is set, a character/letter will be ignored until it occurs this
+     *  many times in the token. Occurances of the character before this number
+     *  will be discarded. Inverse to param `charFrequencyCeiling`.
+     */
+    UInt charFrequencyFloor = 0u;
+
+    /**
      * @param :caseSensitivity: Should capitalized English letters (A-Z) have
      *  differing influence on our output than their lower-cased (a-z)
      *  counterparts?
@@ -63,6 +80,23 @@ namespace htm {
     Real sparsity = 0.0f;
 
     /**
+     * @param :tokenFrequencyCeiling: The max number of times a token can be
+     *  repeated in a document. Occurances of the token beyond this number will
+     *  be discarded. A setting of 1 will act as token de-duplication,
+     *  guaranteeing each token in a document is unique. Inverse to param
+     *  `tokenFrequencyFloor`.
+     */
+    UInt tokenFrequencyCeiling = 0u;
+
+    /**
+     * @param :tokenFrequencyFloor: If this option is set, a token will be
+     *  ignored until it occurs this many times in the document. Occurances of
+     *  the token before this number will be discarded. Inverse to param
+     *  `tokenFrequencyCeiling`.
+     */
+    UInt tokenFrequencyFloor = 0u;
+
+    /**
      * @param :tokenSimilarity: In addition to document similarity, we can also
      *  achieve a kind of token similarity. Default is FALSE (providing better
      *  document-level similarity, at the expense of token-level similarity).
@@ -72,10 +106,12 @@ namespace htm {
      *  input data.
      *    If TRUE: Similar tokens ("cat", "cats") will have similar influence
      *      on the output simhash. This benefit comes with the cost of a
-     *      probable reduction in document-level similarity accuracy.
+     *      probable reduction in document-level similarity accuracy. Params
+     *      `charFrequencyCeiling` and `charFrequencyFloor` are also available
+     *      for use with this.
      *    If FALSE: Similar tokens ("cat", "cats") will have individually unique
-     *      and unrelated influence on the output simhash encoding, thus losing
-     *      token-level similarity and increasing document-level similarity.
+     *      and unrelated influence on the output simhash encoding. This lowers
+     *      token-level similarity and increases document-level similarity.
      */
     bool tokenSimilarity = false;
   }; // end struct SimHashDocumentEncoderParameters
@@ -93,11 +129,6 @@ namespace htm {
    * high overlap), not semantic similarity (encodings for "apple" and
    * "computer" will have no relation here.) For document encodings which are
    * also semantic, please try Cortical.io and their Semantic Folding encoding.
-   *
-   * In addition to document similarity, an option is provided to toggle if
-   * token similarity "near-spellings" (such as "cat" and "cats") will receieve
-   * similar encodings or not. Another option is provided for manging
-   * English-language token case in/sensitivity.
    *
    * Definition of Terms:
    *    A "corpus" is a collection of "documents".
@@ -218,9 +249,13 @@ namespace htm {
       std::string name = "SimHashDocumentEncoder";
       ar(cereal::make_nvp("name", name));
       ar(cereal::make_nvp("activeBits", args_.activeBits));
+      ar(cereal::make_nvp("charFrequencyCeiling", args_.charFrequencyCeiling));
+      ar(cereal::make_nvp("charFrequencyFloor", args_.charFrequencyFloor));
       ar(cereal::make_nvp("caseSensitivity", args_.caseSensitivity));
       ar(cereal::make_nvp("sparsity", args_.sparsity));
       ar(cereal::make_nvp("size", args_.size));
+      ar(cereal::make_nvp("tokenFrequencyCeiling", args_.tokenFrequencyCeiling));
+      ar(cereal::make_nvp("tokenFrequencyFloor", args_.tokenFrequencyFloor));
       ar(cereal::make_nvp("tokenSimilarity", args_.tokenSimilarity));
     }
     // Cereal Deserialize
@@ -229,9 +264,13 @@ namespace htm {
       std::string name;
       ar(cereal::make_nvp("name", name));
       ar(cereal::make_nvp("activeBits", args_.activeBits));
+      ar(cereal::make_nvp("charFrequencyCeiling", args_.charFrequencyCeiling));
+      ar(cereal::make_nvp("charFrequencyFloor", args_.charFrequencyFloor));
       ar(cereal::make_nvp("caseSensitivity", args_.caseSensitivity));
       ar(cereal::make_nvp("sparsity", args_.sparsity));
       ar(cereal::make_nvp("size", args_.size));
+      ar(cereal::make_nvp("tokenFrequencyCeiling", args_.tokenFrequencyCeiling));
+      ar(cereal::make_nvp("tokenFrequencyFloor", args_.tokenFrequencyFloor));
       ar(cereal::make_nvp("tokenSimilarity", args_.tokenSimilarity));
       BaseEncoder<std::map<std::string, UInt>>::initialize({ args_.size });
     }

--- a/src/htm/encoders/SimHashDocumentEncoder.hpp
+++ b/src/htm/encoders/SimHashDocumentEncoder.hpp
@@ -68,15 +68,15 @@ namespace htm {
     bool caseSensitivity = false;
 
     /**
-     * @param :encodeOrphans: Should we `encode()` tokens that are not in our
-     *  `vocabulary`?
-     *    If True (default): Unrecognized tokens will be added to our encoding
+     * @param :encodeOrphans: If param `vocabulary` is set, should we
+      `encode()` tokens not in that `vocabulary` ("orphan" tokens)?
+     *    If True: Unrecognized tokens will be added to our encoding
      *      with weight=1. Our `vocabulary` is useful as a simple weight map.
-     *    If False: Unrecognized tokens will be discarded. Our `vocabulary`
-     *      now serves more like a whitelist (also with weights).
+     *    If False (default): Unrecognized tokens will be discarded. Our
+     *      `vocabulary` now serves more like a whitelist (also with weights).
      *    Any tokens in the `exclude` list will be discarded.
      */
-    bool encodeOrphans = true;
+    bool encodeOrphans = false;
 
     /**
      * @param :excludes: List of tokens to discard when passed in to `encode()`.

--- a/src/test/unit/encoders/SimHashDocumentEncoderTest.cpp
+++ b/src/test/unit/encoders/SimHashDocumentEncoderTest.cpp
@@ -21,6 +21,9 @@
  * SimHashDocumentEncoderTest.cpp
  */
 
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 
 #include <htm/encoders/SimHashDocumentEncoder.hpp>
@@ -31,14 +34,14 @@ namespace testing {
   using namespace htm;
 
   /* Shared Test Strings */
-  const std::vector<std::string> testDoc1 =
-    { "abcde", "fghij",  "klmno",  "pqrst",  "uvwxy"  };
-  const std::vector<std::string> testDoc2 =
-    { "klmno", "pqrst",  "uvwxy",  "z1234",  "56789"  };
-  const std::vector<std::string> testDoc3 =
-    { "z1234", "56789",  "0ABCD",  "EFGHI",  "JKLMN"  };
-  const std::vector<std::string> testDoc4 =
-    { "z1234", "56789P", "0ABCDP", "EFGHIP", "JKLMNP" };
+  const std::vector<std::string> testDoc1 = {
+    "abcde", "fghij",  "klmno",  "pqrst",  "uvwxy"  };
+  const std::vector<std::string> testDoc2 = {
+    "klmno", "pqrst",  "uvwxy",  "z1234",  "56789"  };
+  const std::vector<std::string> testDoc3 = {
+    "z1234", "56789",  "0ABCD",  "EFGHI",  "JKLMN"  };
+  const std::vector<std::string> testDoc4 = {
+    "z1234", "56789P", "0ABCDP", "EFGHIP", "JKLMNP" };
 
 
   /**
@@ -136,15 +139,23 @@ namespace testing {
     params.size = 400u;
     params.activeBits = 20u;
 
+    // basic list calling style
     SDR output({ params.size });
     SimHashDocumentEncoder encoder(params);
-
     const std::vector<std::string> value({});
-    EXPECT_ANY_THROW(encoder.encode(value, output));   // empty
-    EXPECT_NO_THROW(encoder.encode(testDoc1, output)); // full
-
+    EXPECT_ANY_THROW(encoder.encode(value, output));    // empty list
+    EXPECT_NO_THROW(encoder.encode(testDoc1, output));  // full list
     ASSERT_EQ(output.size, params.size);
     ASSERT_EQ(output.getSum(), params.activeBits);
+
+    // make sure simple alternate string calling style matches
+    SDR output2({ params.size });
+    SimHashDocumentEncoder encoder2(params);
+    std::string value2 = "";
+    EXPECT_ANY_THROW(encoder.encode(value2, output2));  // empty str
+    value2 = "abcde fghij klmno pqrst uvwxy";
+    encoder2.encode(value2, output2);                  // full str
+    ASSERT_EQ(output.getSparse(), output2.getSparse());
   }
 
   // Test excludes param
@@ -176,30 +187,29 @@ namespace testing {
     ASSERT_NE(output1, output2); // full != part
     ASSERT_NE(output1, output3); // full != (full - nope)
     ASSERT_EQ(output2, output3); // part == (full - nope)
+  }
 
   // Test character frequency floor/ceiling
   TEST(SimHashDocumentEncoder, testFrequencyChar) {
-    const std::string charTokens = "abbbbccc aabccc aaabcc aabc aabbcccc";
+    const std::string charTokens = {
+      "abbbbbbcccdefg aaaaaabccchijk aaabcccccclmno" };
 
-    SimHashDocumentEncoderParameters params1;
-    params1.size = 400u;
-    params1.activeBits = 20u;
-    params1.tokenSimilarity = true;
-    SimHashDocumentEncoder encoder1(params1);
+    SimHashDocumentEncoderParameters params;
+    params.size = 400u;
+    params.sparsity = 0.33f;
+    params.tokenSimilarity = true;
+    SimHashDocumentEncoder encoder1(params);
     SDR output1({ encoder1.size });
     encoder1.encode(charTokens, output1);
 
-    SimHashDocumentEncoderParameters params2;
-    params2 = params1;
-    params2.charFrequencyFloor = 1;
-    SimHashDocumentEncoder encoder2(params2);
+    params.charFrequencyFloor = 1u;
+    SimHashDocumentEncoder encoder2(params);
     SDR output2({ encoder2.size });
     encoder2.encode(charTokens, output2);
 
-    SimHashDocumentEncoderParameters params3;
-    params3 = params1;
-    params2.charFrequencyCeiling = 4;
-    SimHashDocumentEncoder encoder3(params3);
+    params.charFrequencyFloor = 0;
+    params.charFrequencyCeiling = 3u;
+    SimHashDocumentEncoder encoder3(params);
     SDR output3({ encoder3.size });
     encoder3.encode(charTokens, output3);
 
@@ -212,24 +222,21 @@ namespace testing {
   TEST(SimHashDocumentEncoder, testFrequencyToken) {
     const std::string tokens = "a a a b b c d d d d e e f"; // min 1 max 4
 
-    SimHashDocumentEncoderParameters params1;
-    params1.size = 400u;
-    params1.activeBits = 20u;
-    SimHashDocumentEncoder encoder1(params1);
+    SimHashDocumentEncoderParameters params;
+    params.size = 400u;
+    params.sparsity = 0.33f;
+    SimHashDocumentEncoder encoder1(params);
     SDR output1({ encoder1.size });
     encoder1.encode(tokens, output1);
 
-    SimHashDocumentEncoderParameters params2;
-    params2 = params1;
-    params2.tokenFrequencyFloor = 1;
-    SimHashDocumentEncoder encoder2(params2);
+    params.tokenFrequencyFloor = 1u;
+    SimHashDocumentEncoder encoder2(params);
     SDR output2({ encoder2.size });
     encoder2.encode(tokens, output2);
 
-    SimHashDocumentEncoderParameters params3;
-    params3 = params1;
-    params2.tokenFrequencyCeiling = 4;
-    SimHashDocumentEncoder encoder3(params3);
+    params.tokenFrequencyFloor = 0;
+    params.tokenFrequencyCeiling = 4u;
+    SimHashDocumentEncoder encoder3(params);
     SDR output3({ encoder3.size });
     encoder3.encode(tokens, output3);
 
@@ -240,20 +247,27 @@ namespace testing {
 
   // Test Serialization and Deserialization
   TEST(SimHashDocumentEncoder, testSerialize) {
+    std::map<std::string, UInt> vocab = {
+      { "hear", 2 }, { "nothing", 4 }, { "but", 1 }, { "a", 1 },
+      { "rushing", 4 }, { "sound", 3 } };
+    std::vector<std::string> document = {
+      "hear", "any", "sound", "sound", "louder", "but", "walls" };
+
     SimHashDocumentEncoderParameters params;
     params.size = 400u;
     params.sparsity = 0.33f;
+    params.vocabulary = vocab;
 
     SimHashDocumentEncoder encoder1(params);
     std::stringstream buffer;
     encoder1.save(buffer);
     SDR output1({ encoder1.size });
-    encoder1.encode(testDoc1, output1);
+    encoder1.encode(document, output1);
 
     SimHashDocumentEncoder encoder2;
     encoder2.load(buffer);
     SDR output2({ encoder2.size });
-    encoder2.encode(testDoc1, output2);
+    encoder2.encode(document, output2);
 
     ASSERT_EQ(output1.size, output2.size);
     ASSERT_EQ(output1.getDense(), output2.getDense());
@@ -305,8 +319,6 @@ namespace testing {
     SimHashDocumentEncoderParameters params4;
     params4.size = 400u;
     params4.sparsity = 0.33f;
-    params4.caseSensitivity = false;
-    params4.encodeOrphans = false;
     params4.vocabulary = vocab;
     SimHashDocumentEncoder encoder4(params4);
     SDR output4a({ params4.size });
@@ -369,7 +381,6 @@ namespace testing {
     SimHashDocumentEncoderParameters params;
     params.size = 400u;
     params.sparsity = 0.33f;
-    params.tokenSimilarity = false;
     params.vocabulary = weights;
     SimHashDocumentEncoder encoder(params);
     SDR output1({ params.size });


### PR DESCRIPTION
Simhash Token/Char Frequency Floor/Ceiling, and more.

 Token/Char Frequency Floors/Ceilings.

- C++ and tests, Py bindings and tests.
- This also takes care of de-duplication feature.
- Make new param `encodeOrphans` only work when `vocabulary` is set.
  - Default=false now also
- Fixed alternative `encode(string)` calling across Python binding.
- Improved detail on all serialization tests to include `vocabulary` param,
  and output SDR comparison.
- Switch from `this[style]` of map access to the `more.at(formal)` style,
  in general. (My JS background keeps causing me to use the old style
  incorrectly, with hard to find bug results).
- Fix Python files to match PEP8: indentation style, line length, 4 spaces, etc.
  Sorry for the large reformat. The only changes were adding new params.
- Documentation, etc.
- Re-arranged a few things to get into alphabetical order for easier reading.

